### PR TITLE
Delete .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-//npm.greensock.com/:_authToken=b4784454-c4af-4612-9f2d-e6215b6b9bb7
-@gsap:registry=https://npm.greensock.com


### PR DESCRIPTION
## プライベート情報の削除
アクセストークンなどの重要な情報をgithub上に公開することは極めて危険性が高く、NG行為とされています。
